### PR TITLE
Apply Gallery Color To Size, Not Index

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -44,7 +44,7 @@ a:hover {
 .over18 {
     color: #f99;
 }
-.gallery {
+.galleryCount {
     color: rgb(158, 217, 8);
 }
 .navbox ul li a {

--- a/js/script.js
+++ b/js/script.js
@@ -419,12 +419,11 @@ $(function () {
                 .data("index", i-(rp.photos[i].galleryItem-1))
                 .attr("title", rp.photos[i].title)
                 .attr("id", "numberButton" + ((i + 1)-(rp.photos[i].galleryTotal-1)))
-                .addClass("gallery")    
                 .addClass("numberButton")
+                .addClass("gallery");
+            numberButton.append($("<a />").html("/"+rp.photos[i].galleryTotal).css({fontSize: 10}).addClass("galleryCount"))
             if (pic.over18) {
-                numberButton.append($("<a />").html("/"+rp.photos[i].galleryTotal).css({fontSize: 10}).addClass("over18"))
-            } else {
-                numberButton.append($("<a />").html("/"+rp.photos[i].galleryTotal).css({fontSize: 10}))
+                numberButton.addClass("over18");
             }
             numberButton.click(function () {
                 showImage($(this))


### PR DESCRIPTION
There are some minor issues with formatting in the current version. Currently, this adds the `gallery` class to the post index in the lower left corner, which turns it green, then appends the size of the gallery as a hyperlink. This results in the post index changing color between green and white (depending on whether it's a gallery) while the gallery is always white when it appears.

This can be slightly confusing to read, as the color of the post index changes based on whether the post is a gallery, and when the post is a gallery, the _size_ of the gallery becomes the same color that the _index_ usually is. Color-coding is lost.

This PR changes the formatting so that gallery size is displayed in green (to indicate a gallery), and color of the post index is unaffected by whether it is a gallery.