### PR TITLE
Fix Onscreen Arrow Button Navigation

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -90,7 +90,7 @@ $(function () {
     //setupFadeoutOnIdle();
 
     var getNextSlideIndex = function (currentIndex,x) {
-        if(!x){
+        if(typeof x !== "number"){
             var x = 1
         }
         if (!rp.settings.nsfw) {

--- a/js/script.js
+++ b/js/script.js
@@ -89,30 +89,30 @@ $(function () {
     // and instead the minimize buttons should be used.
     //setupFadeoutOnIdle();
 
-    var getNextSlideIndex = function (currentIndex,x) {
-        if(typeof x !== "number"){
-            var x = 1
+    var getNextSlideIndex = function (currentIndex, skipCount) {
+        if(typeof skipCount !== "number"){
+            var skipCount = 1
         }
         if (!rp.settings.nsfw) {
             // Skip any nsfw if you should
-            for (var i = currentIndex + x; i < rp.photos.length; i++) {
+            for (var i = currentIndex + skipCount; i < rp.photos.length; i++) {
                 if (!rp.photos[i].over18) {
                     return i;
                 }
             }
             return 0;
         }
-        if (isLastImage(getNextSlideIndex) && !rp.session.loadingNextImages) {
+        if (isLastImage(currentIndex) && !rp.session.loadingNextImages) {
             // The only reason we got here and there aren't more pictures yet
             // is because there are no more images to load, start over
             return 0;
         }
         // Just go to the next slide, this should be the common case
-        return currentIndex + x;
+        return currentIndex + skipCount;
     };
 
-    function nextSlide(x) {
-        var next = getNextSlideIndex(rp.session.activeIndex,x);
+    function nextSlide(skipCount) {
+        var next = getNextSlideIndex(rp.session.activeIndex,skipCount);
         saveHistory(next);
         startAnimation(next);
     }  
@@ -873,8 +873,8 @@ $(function () {
         if (!photo.data.is_gallery){
             return
         }
-        var x = (photo.galleryTotal - photo.galleryItem)+1
-        nextSlide(x)
+        var skipCount = (photo.galleryTotal - photo.galleryItem)+1
+        nextSlide(skipCount)
     };
 
     var verifyNsfwMakesSense = function () {


### PR DESCRIPTION
Currently broken in a confusing way because when the arrow buttons are clicked, it passes an Event object to the `nextSlide` function, which happens to take the place of the variable `x` that indicates how far ahead to go.

The `nextSlide` function passes its `x` to `getNextSlideIndex`, which expects either a number (indicating how far to skip) or a null (existing code which doesn't pass any arguments). When passed an object, it would return 0 in the case where nsfw was disabled (since the for loop would exit when you tried to increment a string), and when nsfw was enabled it would happily return a string of the form `"10[object Object]"` which would crash some later function that tried to use it as a number.

This PR fixes it, and also renames the vague `x` variable to `skipCount`.